### PR TITLE
fix(cel): handle `icontains` function

### DIFF
--- a/lib/eval.go
+++ b/lib/eval.go
@@ -164,6 +164,10 @@ func NewEnvOption() CustomLib {
 				decls.NewInstanceOverload("reverse_wait_int",
 					[]*exprpb.Type{decls.Any, decls.Int},
 					decls.Bool)),
+			decls.NewFunction("icontains",
+				decls.NewInstanceOverload("icontains_string",
+					[]*exprpb.Type{decls.String, decls.String},
+					decls.Bool)),
 		),
 	}
 	c.programOptions = []cel.ProgramOption{
@@ -369,6 +373,21 @@ func NewEnvOption() CustomLib {
 						return types.ValOrErr(rhs, "unexpected type '%v' passed to 'wait'", rhs.Type())
 					}
 					return types.Bool(reverseCheck(reverse, timeout))
+				},
+			},
+			&functions.Overload{
+				Operator: "icontains_string",
+				Binary: func(lhs ref.Val, rhs ref.Val) ref.Val {
+					v1, ok := lhs.(types.String)
+					if !ok {
+						return types.ValOrErr(lhs, "unexpected type '%v' passed to bcontains", lhs.Type())
+					}
+					v2, ok := rhs.(types.String)
+					if !ok {
+						return types.ValOrErr(rhs, "unexpected type '%v' passed to bcontains", rhs.Type())
+					}
+					// 不区分大小写包含
+					return types.Bool(strings.Contains(strings.ToLower(string(v1)), strings.ToLower(string(v2))))
 				},
 			},
 		),


### PR DESCRIPTION
处理 yml poc 中 icontains 函数，该函数为大小写不敏感的contains

* 在xray的poc仓库中有2个poc用了该函数：
![image](https://user-images.githubusercontent.com/22260242/91928520-dd849480-ed0e-11ea-86d3-57ee6f36f35e.png)

* 在官方文档中没找到该函数的定义，于是我跑去群里问了p师傅
![image](https://user-images.githubusercontent.com/22260242/91928701-4c61ed80-ed0f-11ea-9f72-e37e3d569cb5.png)
